### PR TITLE
us gc artifact action wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: zip -ry opencv2.xcframework.zip build/opencv2.xcframework
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: gamechanger/upload-artifact-action@v1
         with:
           name: opencv2.xcframework.zip
           path: opencv/opencv2.xcframework.zip


### PR DESCRIPTION
using gc artifcact action wrapper
per infosec all third party actions must be pinned to the specific SHA and not a semantic version